### PR TITLE
Add accessible welcome UI and brand guidelines

### DIFF
--- a/brand_rules.md
+++ b/brand_rules.md
@@ -1,0 +1,33 @@
+# KernelCoder Brand Rules
+
+## Brand Concept
+KernelCoder is a direct, no-nonsense platform for learning low-level programming. The design embraces clarity and accessibility while maintaining a modern aesthetic.
+
+### Tone
+- Professional but approachable
+- Clear and jargon-free language
+- Encourage experimentation and learning by doing
+
+### Visual Style
+- Minimal interface with ample white space
+- Dark and light themes with high contrast
+- Primary accent color: `#3b82f6` (blue)
+- Fonts: Geist Sans for body text, Geist Mono for code snippets
+- Avoid excessive decoration or animations
+
+### Accessibility
+- All interactive elements must be keyboard navigable
+- Provide meaningful `aria` labels and alt text
+- Maintain WCAG AA color contrast
+- Include skip navigation links on every page
+
+### Logo Usage
+- Keep the logo simple and monochrome when possible
+- Do not stretch or distort the logo
+
+### Content Guidelines
+- Focus on practical skills and clear explanations
+- Avoid marketing hype or filler text
+
+---
+Adhering to these rules helps keep the KernelCoder brand consistent and user friendly.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,24 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+.skip-link {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  left: 1rem;
+  top: 1rem;
+  width: auto;
+  height: auto;
+  padding: 0.5rem 1rem;
+  background: var(--foreground);
+  color: var(--background);
+  border-radius: 0.25rem;
+  z-index: 50;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,6 +27,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <a href="#main" className="skip-link">Skip to content</a>
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,114 +1,21 @@
-
-import BashEditor from './components/BashEditor';
-
-
-// export default function Home() {
-//   return (
-//     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-//       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-//         <Image
-//           className="dark:invert"
-//           src="/next.svg"
-//           alt="Next.js logo"
-//           width={180}
-//           height={38}
-//           priority
-//         />
-//         <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-//           <li className="mb-2 tracking-[-.01em]">
-//             Get started by editing{" "}
-//             <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-//               src/app/page.tsx
-//             </code>
-//             .
-//           </li>
-//           <li className="tracking-[-.01em]">
-//             Save and see your changes instantly.
-//           </li>
-//         </ol>
-
-//         <div className="flex gap-4 items-center flex-col sm:flex-row">
-//           <a
-//             className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-//             href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-//             target="_blank"
-//             rel="noopener noreferrer"
-//           >
-//             <Image
-//               className="dark:invert"
-//               src="/vercel.svg"
-//               alt="Vercel logomark"
-//               width={20}
-//               height={20}
-//             />
-//             Deploy now
-//           </a>
-//           <a
-//             className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-//             href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-//             target="_blank"
-//             rel="noopener noreferrer"
-//           >
-//             Read our docs
-//           </a>
-//         </div>
-//       </main>
-//       <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-//         <a
-//           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-//           href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-//           target="_blank"
-//           rel="noopener noreferrer"
-//         >
-//           <Image
-//             aria-hidden
-//             src="/file.svg"
-//             alt="File icon"
-//             width={16}
-//             height={16}
-//           />
-//           Learn
-//         </a>
-//         <a
-//           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-//           href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-//           target="_blank"
-//           rel="noopener noreferrer"
-//         >
-//           <Image
-//             aria-hidden
-//             src="/window.svg"
-//             alt="Window icon"
-//             width={16}
-//             height={16}
-//           />
-//           Examples
-//         </a>
-//         <a
-//           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-//           href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-//           target="_blank"
-//           rel="noopener noreferrer"
-//         >
-//           <Image
-//             aria-hidden
-//             src="/globe.svg"
-//             alt="Globe icon"
-//             width={16}
-//             height={16}
-//           />
-//           Go to nextjs.org →
-//         </a>
-//       </footer>
-//     </div>
-//   );
-// }
+import Link from "next/link";
 
 export default function Home() {
   return (
-    <main className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Bash Sandbox</h1>
-      <BashEditor />
+    <main
+      id="main"
+      className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center"
+    >
+      <h1 className="text-4xl font-semibold tracking-tight">KernelCoder</h1>
+      <p className="text-lg max-w-prose text-balance">
+        Learn from the bottom up. Code from the core.
+      </p>
+      <Link
+          href="/sandbox"
+          className="rounded-md bg-foreground text-background px-6 py-3 font-medium hover:bg-opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground"
+        >
+          Get Started
+        </Link>
     </main>
   );
 }

--- a/src/app/sandbox/page.tsx
+++ b/src/app/sandbox/page.tsx
@@ -1,0 +1,10 @@
+import BashEditor from "../components/BashEditor";
+
+export default function SandboxPage() {
+  return (
+    <main className="p-4" id="main">
+      <h1 className="text-2xl font-bold mb-4">Bash Sandbox</h1>
+      <BashEditor />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- create an accessible welcome screen with clear call to action
- move Bash editor to `/sandbox`
- add skip navigation link to layout and supporting styles
- document design principles in `brand_rules.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686260e418d08326aa7da0d47776781c