### PR TITLE
Add navigation bar

### DIFF
--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -1,0 +1,53 @@
+import Link from 'next/link';
+
+export default function NavBar() {
+  return (
+    <header className="border-b border-gray-200">
+      <nav className="mx-auto flex max-w-7xl items-center justify-between p-4" aria-label="Main navigation">
+        <Link href="/" className="text-lg font-semibold hover:text-blue-500">
+          KernelCoder
+        </Link>
+        <ul className="hidden gap-6 md:flex">
+          <li>
+            <Link href="#" className="hover:text-blue-500">
+              Pricing
+            </Link>
+          </li>
+          <li>
+            <Link href="#" className="hover:text-blue-500">
+              Catalogue
+            </Link>
+          </li>
+          <li>
+            <Link href="#" className="rounded-md bg-blue-500 px-3 py-1.5 text-white hover:bg-blue-600">
+              Try Demo
+            </Link>
+          </li>
+          <li>
+            <Link href="#" className="hover:text-blue-500">
+              Subjects <span aria-hidden="true">▼</span>
+            </Link>
+          </li>
+          <li>
+            <Link href="#" className="hover:text-blue-500">
+              About
+            </Link>
+          </li>
+          <li>
+            <Link href="#" className="hover:text-blue-500">
+              Blog
+            </Link>
+          </li>
+        </ul>
+        <div className="flex items-center gap-4">
+          <Link href="#" className="hover:text-blue-500">
+            Login
+          </Link>
+          <Link href="#" className="hover:text-blue-500">
+            Sign Up
+          </Link>
+        </div>
+      </nav>
+    </header>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import NavBar from "./components/NavBar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,6 +29,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <a href="#main" className="skip-link">Skip to content</a>
+        <NavBar />
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- create `NavBar` component with Pricing, Catalogue, Try Demo and login/signup
- insert `NavBar` into the root layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68626c2d347883268a571751256f958e