### PR TITLE
Implement hero section with interactive slideshow

### DIFF
--- a/src/app/components/DarkModeToggle.tsx
+++ b/src/app/components/DarkModeToggle.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function DarkModeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('dark');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') {
+      setTheme(stored);
+      document.documentElement.classList.toggle('dark', stored === 'dark');
+    } else {
+      document.documentElement.classList.add('dark');
+    }
+  }, []);
+
+  const toggle = () => {
+    const next = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    document.documentElement.classList.toggle('dark', next === 'dark');
+    localStorage.setItem('theme', next);
+  };
+
+  return (
+    <button onClick={toggle} className="p-2" aria-label="Toggle dark mode">
+      {theme === 'dark' ? '🌙' : '☀️'}
+    </button>
+  );
+}

--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -1,0 +1,95 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+export default function Hero() {
+  const taglines = [
+    'We teach how it works, not just what to type.',
+    'Learn low-level programming the smart way.',
+    'Try real commands in real sandboxes. No lectures. No fluff.',
+    'Your path from beginner to bit-level mastery starts here.',
+    'Hack the kernel, step by step.',
+    'Hands-on labs for C, Bash, and Assembly.',
+    'Build a solid foundation for systems programming.',
+    'Grow from newbie to pro with focused practice.',
+    'Interactive lessons that go beyond theory.',
+    'Master the tools every developer should know.'
+  ];
+
+  const [index, setIndex] = useState(0);
+  const [showForm, setShowForm] = useState(false);
+  const [signup, setSignup] = useState(false);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % taglines.length);
+    }, 3000);
+    return () => clearInterval(id);
+  }, [taglines.length]);
+
+  return (
+    <section className="relative flex flex-col md:flex-row min-h-screen items-center justify-center p-8 gap-8">
+      <div className="w-full md:w-1/2 space-y-6 text-left">
+        <div className="h-24 relative overflow-hidden">
+          {taglines.map((line, i) => (
+            <p
+              key={line}
+              className={`font-mono text-3xl whitespace-nowrap absolute inset-0 flex items-center transition-opacity duration-700 ${i === index ? 'opacity-100' : 'opacity-0'}`}
+            >
+              {line}
+            </p>
+          ))}
+        </div>
+        <p className="text-lg font-sans">A modern playground for Bash, C, and Assembly learners.</p>
+      </div>
+      <div className="w-full md:w-1/2 relative flex flex-col items-center justify-center">
+        <img src="/hero_right_bottom.jpeg" alt="" aria-hidden="true" className="absolute inset-0 w-full h-full object-cover opacity-70 blur-sm" />
+        <img src="/hero_right_top.png" alt="Terminal sandbox example" className="relative z-10 shadow-xl" />
+        <button
+          onClick={() => setShowForm(true)}
+          className="relative z-20 mt-4 rounded-md px-6 py-3 font-medium text-black bg-[#FDD835] hover:bg-[#e6c62f] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+        >
+          Try It Now
+        </button>
+        <span className="relative z-20 text-sm mt-2">No account required</span>
+        {showForm && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm" onClick={() => setShowForm(false)}>
+            <div className="bg-background text-foreground p-6 rounded-md shadow-lg w-80" onClick={(e) => e.stopPropagation()}>
+              <div className="flex mb-4 border-b border-gray-200">
+                <button
+                  onClick={() => setSignup(false)}
+                  className={`flex-1 p-2 ${!signup ? 'border-b-2 border-[#FDD835]' : ''}`}
+                >
+                  Sign In
+                </button>
+                <button
+                  onClick={() => setSignup(true)}
+                  className={`flex-1 p-2 ${signup ? 'border-b-2 border-[#FDD835]' : ''}`}
+                >
+                  Sign Up
+                </button>
+              </div>
+              <form className="space-y-4">
+                <label className="block">
+                  <span className="sr-only">Email</span>
+                  <input type="email" placeholder="Email" className="w-full rounded border border-gray-300 p-2 bg-transparent" />
+                </label>
+                <label className="block">
+                  <span className="sr-only">Password</span>
+                  <input type="password" placeholder="Password" className="w-full rounded border border-gray-300 p-2 bg-transparent" />
+                </label>
+                <div className="flex items-center gap-2">
+                  <input id="remember" type="checkbox" className="rounded" />
+                  <label htmlFor="remember" className="text-sm">Remember Me</label>
+                </div>
+                <button type="submit" className="w-full rounded-md px-4 py-2 bg-[#FDD835] text-black hover:bg-[#e6c62f]">
+                  {signup ? 'Get Started' : 'Continue'}
+                </button>
+                <a href="#" className="block text-sm text-right underline">Forgot Password</a>
+              </form>
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import DarkModeToggle from './DarkModeToggle';
 
 export default function NavBar() {
   return (
@@ -40,6 +41,7 @@ export default function NavBar() {
           </li>
         </ul>
         <div className="flex items-center gap-4">
+          <DarkModeToggle />
           <Link href="#" className="hover:text-blue-500">
             Login
           </Link>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,8 +8,6 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -19,10 +17,19 @@
   }
 }
 
+html.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans, Inter, sans-serif);
+}
+
+.font-mono, code, pre {
+  font-family: var(--font-mono, "Fira Code", monospace);
 }
 
 .skip-link {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,18 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, Fira_Code } from "next/font/google";
 import "./globals.css";
 import NavBar from "./components/NavBar";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-sans",
   subsets: ["latin"],
+  display: "swap",
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const fira = Fira_Code({
+  variable: "--font-mono",
   subsets: ["latin"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -25,9 +27,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${inter.variable} ${fira.variable} antialiased`}>
         <a href="#main" className="skip-link">Skip to content</a>
         <NavBar />
         {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,5 @@
-import Link from "next/link";
+import Hero from "./components/Hero";
 
 export default function Home() {
-  return (
-    <main
-      id="main"
-      className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center"
-    >
-      <h1 className="text-4xl font-semibold tracking-tight">KernelCoder</h1>
-      <p className="text-lg max-w-prose text-balance">
-        Learn from the bottom up. Code from the core.
-      </p>
-      <Link
-          href="/sandbox"
-          className="rounded-md bg-foreground text-background px-6 py-3 font-medium hover:bg-opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground"
-        >
-          Get Started
-        </Link>
-    </main>
-  );
+  return <Hero />;
 }


### PR DESCRIPTION
## Summary
- add interactive hero component with rotating taglines
- include sign-in/sign-up modal and "Try it now" CTA
- add dark mode toggle in the navigation bar
- switch fonts to Inter and Fira Code
- configure global styles for dark mode and new fonts

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686278e565b48326819bc70fc1181155