### PR TITLE
Add testimonials, footer, and sitemap

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+
+export default function Footer() {
+  const medium = 'https://medium.com/@richfish85/';
+  return (
+    <footer className="border-t border-gray-200 bg-gray-100 dark:bg-gray-900" aria-labelledby="footer-heading">
+      <h2 id="footer-heading" className="sr-only">Footer</h2>
+      <div className="mx-auto max-w-7xl p-6 grid gap-8 sm:grid-cols-2 md:grid-cols-4 text-sm">
+        <div className="space-y-2">
+          <h3 className="font-semibold">KernelCoder</h3>
+          <ul className="space-y-1">
+            <li><Link href="/">Home</Link></li>
+            <li><Link href="/catalogue">Catalogue</Link></li>
+            <li><a href={medium} target="_blank" rel="noopener noreferrer">Articles</a></li>
+            <li><Link href="/about">About / Contact</Link></li>
+          </ul>
+        </div>
+        <div className="space-y-2">
+          <h3 className="font-semibold">Explore by Language</h3>
+          <ul className="space-y-1">
+            <li>Bash</li>
+            <li>C</li>
+            <li>Assembly</li>
+          </ul>
+        </div>
+        <div className="space-y-2">
+          <h3 className="font-semibold">Explore by Subject</h3>
+          <ul className="space-y-1">
+            <li>Memory</li>
+            <li>Syscalls</li>
+            <li>Shells</li>
+          </ul>
+        </div>
+        <div className="space-y-2">
+          <h3 className="font-semibold">More</h3>
+          <ul className="space-y-1">
+            <li><Link href="/sitemap">Sitemap</Link></li>
+            <li><a href={medium} target="_blank" rel="noopener noreferrer">Medium Posts</a></li>
+          </ul>
+        </div>
+      </div>
+      <p className="text-center text-xs py-4">&copy; {new Date().getFullYear()} KernelCoder</p>
+    </footer>
+  );
+}
+

--- a/src/app/components/SellingPoints.tsx
+++ b/src/app/components/SellingPoints.tsx
@@ -5,16 +5,27 @@ export default function SellingPoints() {
     { icon: '✅', text: 'Hands-on from the first minute' },
     { icon: '🧠', text: 'Learn why it works, not just what to type' },
     { icon: '🔒', text: 'Safe command sandbox \u2013 practice without fear' },
-    { icon: '⚙️', text: 'Languages covered: Bash, C, Assembly (with more coming)' },
+    {
+      icon: '⚙️',
+      text: 'Languages covered: Bash, C, Assembly (with more coming)',
+    },
     { icon: '🧑\u200d💻', text: 'For future hackers, engineers & makers' },
   ];
 
   return (
     <section className="py-12" aria-labelledby="selling-heading">
-      <h2 id="selling-heading" className="sr-only">Selling Points</h2>
-      <div className="mx-auto max-w-5xl grid gap-8 sm:grid-cols-2 md:grid-cols-3">
+      <h2
+        id="selling-heading"
+        className="mb-8 text-center text-2xl font-bold tracking-tight"
+      >
+        Why KernelCoder?
+      </h2>
+      <div className="mx-auto max-w-5xl grid gap-6 sm:grid-cols-2 md:grid-cols-3">
         {points.map(({ icon, text }) => (
-          <div key={text} className="flex items-start gap-3">
+          <div
+            key={text}
+            className="flex items-start gap-3 rounded-lg bg-gray-100 p-4 shadow-sm dark:bg-gray-800"
+          >
             <span className="text-2xl" aria-hidden="true">{icon}</span>
             <p className="font-sans leading-snug">{text}</p>
           </div>

--- a/src/app/components/Testimonials.tsx
+++ b/src/app/components/Testimonials.tsx
@@ -1,0 +1,46 @@
+'use client';
+import Image from 'next/image';
+
+export default function Testimonials() {
+  const reviews = [
+    {
+      name: 'Alex J.',
+      quote: 'I finally understand what pointers are doing under the hood.',
+      img: 'https://i.pravatar.cc/80?img=10',
+    },
+    {
+      name: 'Mia L.',
+      quote:
+        'The interactive shell taught me more in 1 hour than 3 weeks of online tutorials.',
+      img: 'https://i.pravatar.cc/80?img=20',
+    },
+    {
+      name: 'Samir P.',
+      quote: 'Wish I had this before my first internship!',
+      img: 'https://i.pravatar.cc/80?img=30',
+    },
+  ];
+
+  return (
+    <section className="py-12 bg-gray-50 dark:bg-[#111]" aria-labelledby="testimonials-heading">
+      <h2 id="testimonials-heading" className="mb-8 text-center text-2xl font-bold tracking-tight">
+        What Learners Say
+      </h2>
+      <div className="mx-auto max-w-5xl grid gap-8 md:grid-cols-3">
+        {reviews.map(({ name, quote, img }) => (
+          <figure key={name} className="flex flex-col items-center text-center space-y-4">
+            <Image
+              src={img}
+              alt={`Avatar of ${name}`}
+              width={64}
+              height={64}
+              className="h-16 w-16 rounded-full"
+            />
+            <blockquote className="font-serif italic">“{quote}”</blockquote>
+            <figcaption className="font-medium">{name}</figcaption>
+          </figure>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter, Fira_Code } from "next/font/google";
 import "./globals.css";
 import NavBar from "./components/NavBar";
+import Footer from "./components/Footer";
 
 const inter = Inter({
   variable: "--font-sans",
@@ -31,7 +32,9 @@ export default function RootLayout({
         <a href="#main" className="skip-link">Skip to content</a>
         <NavBar />
         {children}
+        <Footer />
       </body>
     </html>
   );
 }
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,14 @@
 import Hero from "./components/Hero";
 import SellingPoints from "./components/SellingPoints";
+import Testimonials from "./components/Testimonials";
 
 export default function Home() {
   return (
     <>
       <Hero />
       <SellingPoints />
+      <Testimonials />
     </>
   );
 }
+

--- a/src/app/sitemap/page.tsx
+++ b/src/app/sitemap/page.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+
+export default function SitemapPage() {
+  const medium = 'https://medium.com/@richfish85/';
+  return (
+    <main id="main" className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Sitemap</h1>
+      <ul className="list-disc ml-6 space-y-1">
+        <li><Link href="/">Home</Link></li>
+        <li><Link href="/catalogue">Catalogue</Link></li>
+        <li>
+          <a href={medium} target="_blank" rel="noopener noreferrer">
+            Articles
+          </a>
+        </li>
+        <li><Link href="/about">About / Contact</Link></li>
+      </ul>
+      <h2 className="text-xl font-semibold">Explore by:</h2>
+      <div className="grid gap-6 sm:grid-cols-3">
+        <div>
+          <h3 className="font-semibold">Languages</h3>
+          <ul className="list-disc ml-5 space-y-1">
+            <li>Bash</li>
+            <li>C</li>
+            <li>Assembly</li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-semibold">Subjects</h3>
+          <ul className="list-disc ml-5 space-y-1">
+            <li>Memory</li>
+            <li>Syscalls</li>
+            <li>Shells</li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-semibold">Articles</h3>
+          <a href={medium} target="_blank" rel="noopener noreferrer" className="underline">
+            Medium Posts
+          </a>
+        </div>
+      </div>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- redesign selling points section
- add testimonials section
- add Footer with quick links
- create sitemap page
- show footer on all pages

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686288ec85a083269f53c30dac723a17